### PR TITLE
Updated a sort command in gwas_qc_part2.sh

### DIFF
--- a/gwas_qc_part2.sh
+++ b/gwas_qc_part2.sh
@@ -147,7 +147,7 @@ fi
 #### remove same-position variants ####
 
 printf "\nStep 4: Removing multi-allelic and duplicated variants.\n"
-awk '{ print $2" "$1"_"$4 }' ${output}.bim | sort  -k2 | uniq -f1 -D | awk '{ print $1 }' > ${output}_samepos_vars.txt
+awk '{ print $2" "$1"_"$4 }' ${output}.bim | sort -T /ref/ -k2 | uniq -f1 -D | awk '{ print $1 }' > ${output}_samepos_vars.txt
 
 if [ "$( wc -l < ${output}_samepos_vars.txt )" -gt 0 ];
 then


### PR DESCRIPTION
I edited a command in gwas_qc_part2 to write temporary "sort" output to the /ref/ directory instead of the /tmp/ directory. When running on WRAP I was getting an error with this line. 